### PR TITLE
solve `different device` issue by adding `.to(self.device)` at output

### DIFF
--- a/fruit_nerf/fruit_nerf.py
+++ b/fruit_nerf/fruit_nerf.py
@@ -404,7 +404,7 @@ class FruitModel(Model):
             self, outputs: Dict[str, torch.Tensor], batch: Dict[str, torch.Tensor]
     ) -> Tuple[Dict[str, float], Dict[str, torch.Tensor]]:
         image = batch["image"].to(self.device)
-        rgb = outputs["rgb"]
+        rgb = outputs["rgb"].to(self.device)
         rgb = torch.clamp(rgb, min=0, max=1)
         acc = colormaps.apply_colormap(outputs["accumulation"])
         depth = colormaps.apply_depth_colormap(
@@ -452,7 +452,7 @@ class FruitModel(Model):
         from torchmetrics.classification import BinaryJaccardIndex
         metric = BinaryJaccardIndex().to(self.device)
         semantic_labels = torch.nn.functional.softmax(outputs["semantics"])
-        iou = metric(semantic_labels[..., 0], batch["fruit_mask"][..., 0])
+        iou = metric(semantic_labels[..., 0].to(self.device), batch["fruit_mask"][..., 0])
         metrics_dict["iou"] = float(iou)
 
         return metrics_dict, images_dict


### PR DESCRIPTION
I met this problem at evaluation stage with `ns-eval --load-config .....`